### PR TITLE
Alarm fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Serverless AWS Alerts Plugin
+
   [![NPM version][npm-image]][npm-url]
   [![Build Status][travis-image]][travis-url]
   [![Dependency Status][daviddm-image]][daviddm-url]
@@ -7,6 +8,7 @@
 A Serverless plugin to easily add CloudWatch alarms to functions
 
 ## Installation
+
 `npm i serverless-plugin-aws-alerts`
 
 ## Usage
@@ -41,6 +43,19 @@ custom:
         period: 300
         evaluationPeriods: 1
         comparisonOperator: GreaterThanOrEqualToThreshold
+      # the 'cloudformation' property will be merged into the resulting AWS::CloudWatch::Alarm CloudFormation
+      # resource. This is useful if this plugin is not up to date with the latest alarm features, or as an escape hatch
+      customAlarmWithCloudformationEscapeHatch:
+        description: 'My custom alarm with a custm name'
+        namespace: 'AWS/Lambda'
+        metric: duration
+        threshold: 200
+        statistic: Average
+        period: 300
+        evaluationPeriods: 1
+        comparisonOperator: GreaterThanOrEqualToThreshold
+        cloudformation:
+          AlarmName: 'My Custom Alarm Name'
     alarms:
       - functionThrottles
       - functionErrors
@@ -89,6 +104,7 @@ custom:
 You can configure notifications to send to webhook URLs, to SMS devices, to other Lambda functions, and more. Check out the AWS docs [here](http://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html) for configuration options.
 
 ## Metric Log Filters
+
 You can monitor a log group for a function for a specific pattern. Do this by adding the pattern key.
 You can learn about custom patterns at: http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
 
@@ -119,6 +135,7 @@ custom:
 > Note: For custom log metrics, namespace property will automatically be set to stack name (e.g. `fooservice-dev`).
 
 ## Default Definitions
+
 The plugin provides some default definitions that you can simply drop into your application. For example:
 
 ```yaml
@@ -203,7 +220,6 @@ definitions:
 ## License
 
 MIT © [A Cloud Guru](https://acloud.guru/)
-
 
 [npm-image]: https://badge.fury.io/js/serverless-plugin-aws-alerts.svg
 [npm-url]: https://npmjs.org/package/serverless-plugin-aws-alerts

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ custom:
         period: 300
         evaluationPeriods: 1
         comparisonOperator: GreaterThanOrEqualToThreshold
-      # the 'cloudformation' property will be merged into the resulting AWS::CloudWatch::Alarm CloudFormation
+      # the 'cloudFormation' property will be merged into the resulting AWS::CloudWatch::Alarm CloudFormation
       # resource. This is useful if this plugin is not up to date with the latest alarm features, or as an escape hatch
       customAlarmWithCloudformationEscapeHatch:
         description: 'My custom alarm with a custm name'
@@ -54,7 +54,7 @@ custom:
         period: 300
         evaluationPeriods: 1
         comparisonOperator: GreaterThanOrEqualToThreshold
-        cloudformation:
+        cloudFormation:
           AlarmName: 'My Custom Alarm Name'
     alarms:
       - functionThrottles

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "John McKim <john@acloud.guru>",
   "license": "MIT",
   "peerDependencies": {
-    "serverless": "^1.12.0"
+    "serverless": "~1.41.0"
   },
   "dependencies": {
     "lodash": "^4.16.6"

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,9 @@ class AlertsPlugin {
     } else {
       alarm.Properties.ExtendedStatistic = definition.statistic
     }
-    return Object.assign(alarm, (definition.cloudformation || {}));
+    
+    _.merge(alarm.Properties, (definition.cloudFormation || {}));
+    return alarm
   }
 
   getSnsTopicCloudFormation(topicName, notifications) {

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ class AlertsPlugin {
     } else {
       alarm.Properties.ExtendedStatistic = definition.statistic
     }
-    return alarm;
+    return Object.assign(alarm, (definition.cloudformation || {}));
   }
 
   getSnsTopicCloudFormation(topicName, notifications) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -731,7 +731,7 @@ describe('#index', function () {
         }
       });
 
-      it('should merge any \'cloudformation\' keys into the AWS::CloudWatch::Alarm declaration', () => {
+      it('should merge any \'cloudFormation\' keys into the AWS::CloudWatch::Alarm declaration', () => {
         const alertTopics = {
           ok: 'ok-topic',
           alarm: 'alarm-topic',
@@ -748,7 +748,7 @@ describe('#index', function () {
           evaluationPeriods: 1,
           comparisonOperator: 'GreaterThanThreshold',
           treatMissingData: 'breaching',
-          cloudformation: {
+          cloudFormation: {
             AlarmName: 'Custom alarm name',
             Threshold: 35,
             OKActions: ['other-topic'],
@@ -763,19 +763,19 @@ describe('#index', function () {
         expect(cf).toEqual({
           Type: 'AWS::CloudWatch::Alarm',
           Properties: {
-            AlarmName: definition.cloudformation.AlarmName,
+            AlarmName: definition.cloudFormation.AlarmName,
             AlarmDescription: definition.description,
             Namespace: definition.namespace,
             MetricName: definition.metric,
-            Threshold: definition.cloudformation.Threshold,
-            // while technically incorrect syntax, the 'cloudformation' property is an escape-hatch
+            Threshold: definition.cloudFormation.Threshold,
+            // while technically incorrect syntax, the 'cloudFormation' property is an escape-hatch
             // and as such shouldn't follow strict validation if used
-            Statistic: definition.cloudformation.Statistic,
+            Statistic: definition.cloudFormation.Statistic,
             ExtendedStatistic: definition.statistic,
             Period: definition.period,
             EvaluationPeriods: definition.evaluationPeriods,
             ComparisonOperator: definition.comparisonOperator,
-            OKActions: definition.cloudformation.OkActions,
+            OKActions: definition.cloudFormation.OkActions,
             AlarmActions: ['alarm-topic'],
             InsufficientDataActions: ['insufficientData-topic'],
             Dimensions: [{

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -730,6 +730,64 @@ describe('#index', function () {
           TreatMissingData: 'breaching',
         }
       });
+
+      it('should merge any \'cloudformation\' keys into the AWS::CloudWatch::Alarm declaration', () => {
+        const alertTopics = {
+          ok: 'ok-topic',
+          alarm: 'alarm-topic',
+          insufficientData: 'insufficientData-topic',
+        };
+
+        const definition = {
+          description: 'An error alarm',
+          namespace: 'AWS/Lambda',
+          metric: 'Errors',
+          threshold: 1,
+          statistic: 'p95',
+          period: 300,
+          evaluationPeriods: 1,
+          comparisonOperator: 'GreaterThanThreshold',
+          treatMissingData: 'breaching',
+          cloudformation: {
+            AlarmName: 'Custom alarm name',
+            Threshold: 35,
+            OKActions: ['other-topic'],
+            Statistic: 'SampleCount',
+          }
+        };
+
+        const functionRef = 'func-ref';
+
+        const cf = plugin.getAlarmCloudFormation(alertTopics, definition, functionRef);
+
+        expect(cf).toEqual({
+          Type: 'AWS::CloudWatch::Alarm',
+          Properties: {
+            AlarmName: definition.cloudformation.AlarmName,
+            AlarmDescription: definition.description,
+            Namespace: definition.namespace,
+            MetricName: definition.metric,
+            Threshold: definition.cloudformation.Threshold,
+            // while technically incorrect syntax, the 'cloudformation' property is an escape-hatch
+            // and as such shouldn't follow strict validation if used
+            Statistic: definition.cloudformation.Statistic,
+            ExtendedStatistic: definition.statistic,
+            Period: definition.period,
+            EvaluationPeriods: definition.evaluationPeriods,
+            ComparisonOperator: definition.comparisonOperator,
+            OKActions: definition.cloudformation.OkActions,
+            AlarmActions: ['alarm-topic'],
+            InsufficientDataActions: ['insufficientData-topic'],
+            Dimensions: [{
+              Name: 'FunctionName',
+              Value: {
+                Ref: functionRef,
+              }
+            }],
+            TreatMissingData: 'breaching',
+          }
+        });
+      });
     });
-  })
+  });
 });


### PR DESCRIPTION
I probably should have just did this in the first place...

The [serverless-plugin-aws-alerts](https://github.com/ACloudGuru/serverless-plugin-aws-alerts) is pretty useful but no longer maintained. This fork allows us to modify the plugin as we see fit.

For now, I'm simply adding the ability to specify additional alarm properties that aren't supported by the original plugin.